### PR TITLE
Allow copy pasting steam IDs of users.

### DIFF
--- a/application/views/pages/users/edit.php
+++ b/application/views/pages/users/edit.php
@@ -43,7 +43,7 @@
             <div class="control-group">
                 <label class="control-label" for="userSteamID">SteamID</label>
                 <div class="controls">
-                    <input type="text" id="userSteamID" disabled class="input-medium" name="steamid" value="<?php echo $user['steam_id']; ?>">
+                    <input type="text" id="userSteamID" class="input-medium" name="steamid" value="<?php echo $user['steam_id']; ?>">
                 </div>
             </div>
             <div class="control-group">

--- a/application/views/pages/users/edit.php
+++ b/application/views/pages/users/edit.php
@@ -31,7 +31,7 @@
             <div class="control-group">
                 <label class="control-label" for="userSteamID">Auth</label>
                 <div class="controls">
-                    <input type="text" id="userSteamID" class="input-medium" name="auth" value="<?php echo $user['auth']; ?>">
+                    <input type="text" id="userSteamID" readonly class="input-medium" name="auth" value="<?php echo $user['auth']; ?>">
                 </div>
             </div>
             <div class="control-group">


### PR DESCRIPTION
Disabling the input box had a side effect of not being able to select the text. Now you can.

Though you can also edit it now, so be careful.